### PR TITLE
Feature/no result UI

### DIFF
--- a/BeyondCTAProject/UIResource/Generated/Localized.swift
+++ b/BeyondCTAProject/UIResource/Generated/Localized.swift
@@ -9,6 +9,12 @@ import Foundation
 
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 public enum L10n {
+  /// キーワードを変えてもう一度検索してください
+  public static let noResultsAlertBody = L10n.tr("Localizable", "noResultsAlertBody")
+  /// %@ の結果が見つかりませんでした
+  public static func noResultsAlertTitle(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "noResultsAlertTitle", String(describing: p1))
+  }
   /// Enter search words..
   public static let searchPlacaholder = L10n.tr("Localizable", "searchPlacaholder")
 }

--- a/BeyondCTAProject/UIResource/Resource/Localizable/Localizable.strings
+++ b/BeyondCTAProject/UIResource/Resource/Localizable/Localizable.strings
@@ -1,1 +1,3 @@
 "searchPlacaholder" = "Enter search words..";
+"noResultsAlertTitle" = "%@ の結果が見つかりませんでした";
+"noResultsAlertBody" = "キーワードを変えてもう一度検索してください";

--- a/BeyondCTAProject/ViewControllers/HomeViewController.swift
+++ b/BeyondCTAProject/ViewControllers/HomeViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 import SnapKit
 import RxSwift
 import PKHUD
+import SwiftMessages
 
 final class HomeViewController: UIViewController {
     
@@ -90,6 +91,13 @@ final class HomeViewController: UIViewController {
             .bind(to: collectionView.rx.items(cellIdentifier: "cell", cellType: CardCell.self)) { _, item, cell in
                 cell.setupCellData(item: item)
             }.disposed(by: disposeBag)
+                
+        viewModel.output.noResults
+            .subscribe(onNext: { [weak self] _ in
+                guard let me = self,
+                let searchText = me.searchBar.text else { return }
+                me.showNoResultsAlert(searchText: searchText)
+            }).disposed(by: disposeBag)
     }
     
     // MARK: - Helpers
@@ -112,6 +120,18 @@ final class HomeViewController: UIViewController {
             make.left.right.equalToSuperview()
             make.bottom.equalTo(view.safeAreaLayoutGuide)
         }
+    }
+    
+    private func showNoResultsAlert(searchText: String) {
+        let view = MessageView.viewFromNib(layout: .centeredView)
+        view.configureDropShadow()
+        view.configureContent(
+            title: L10n.noResultsAlertTitle(searchText),
+            body: L10n.noResultsAlertBody
+        )
+        view.button?.isHidden = true
+        view.iconLabel?.isHidden = true
+        SwiftMessages.show(view: view)
     }
 }
 

--- a/BeyondCTAProject/ViewModels/CardViewModel.swift
+++ b/BeyondCTAProject/ViewModels/CardViewModel.swift
@@ -43,12 +43,21 @@ final class CardViewModel: UnioStream<CardViewModel>, CardViewModelType {
                         return .just(nil)
                     }
             }.subscribe(onNext: { items in
-                guard let items = items else { return }
+                guard let items = items, !items.isEmpty else {
+                    state.hudHide.accept(())
+                    return state.noResults.accept(())
+                }
                 state.repositoryInfoModels.accept(items)
                 state.hudHide.accept(())
             }).disposed(by: disposeBag)
         
         // MARK: State
+        
+        state.noResults
+            .delay(.milliseconds(700), scheduler: MainScheduler.instance)
+            .subscribe(onNext: { _ in
+                state.hudHide.accept(())
+            }).disposed(by: disposeBag)
         
         state.hudShow
             .filter { $0 == .error || $0 == .success }
@@ -61,6 +70,7 @@ final class CardViewModel: UnioStream<CardViewModel>, CardViewModelType {
             hudShow: state.hudShow.asObservable(),
             hudHide: state.hudHide.asObservable(),
             repositoryInfoModels: state.repositoryInfoModels.asObservable()
+            noResults: state.noResults.asObservable()
         )
     }
 }
@@ -80,6 +90,7 @@ extension CardViewModel {
         let hudShow: Observable<HUDContentType>
         let hudHide: Observable<Void>
         let repositoryInfoModels: Observable<[RepositoryInfoModel]>
+        let noResults: Observable<Void>
     }
     
     //MARK: - State
@@ -88,6 +99,7 @@ extension CardViewModel {
         let hudShow = PublishRelay<HUDContentType>()
         let hudHide = PublishRelay<Void>()
         let repositoryInfoModels = BehaviorRelay<[RepositoryInfoModel]>(value: [])
+        let noResults = PublishRelay<Void>()
     }
     
     // MARK: - Extra

--- a/BeyondCTAProjectTests/CardViewModelTests.swift
+++ b/BeyondCTAProjectTests/CardViewModelTests.swift
@@ -62,6 +62,36 @@ final class CardViewModelTests: XCTestCase {
         XCTAssertEqual(repository.populateRepositoriesCallCount, 1, "populateRepositoriesメソッドが一回だけ呼ばれているか")
         XCTAssertEqual(hudShow.value, .error, "エラーHUDが表示されるか")
         XCTAssertNil(hudHide.value, "HUDが非表示になっているか")
+    func test_noResults() {
+        dependency = Dependency()
+        let testTarget = dependency.testTarget
+        let repository = dependency.searchRepositoryMock
+        let hudShow = WatchStream(testTarget.output.hudShow)
+        let hudHide = WatchStream(testTarget.output.hudHide)
+        let noResultsAlert = WatchStream(testTarget.output.noResults)
+        let repositoryInfoModels = WatchStream(testTarget.output.repositoryInfoModels)
+
+        var query: String?
+        var language: String?
+        var pagingOffset: Int?
+        
+        XCTAssertEqual(repository.populateRepositoriesCallCount, 0, "populateRepositoriesメソッドが呼ばれていないか")
+        repository.populateRepositoriesHandler = { (keyword, lang, offset) in
+            query = keyword
+            language = lang
+            pagingOffset = offset
+            return MockData.singleFetchNoHitRepositoryInfoModel()
+        }
+        
+        testTarget.input.searchText.onNext(.mock)
+        testTarget.input.searchButtonClicked.onNext(())
+        
+        XCTAssertEqual(repository.populateRepositoriesCallCount, 1, "populateRepositoriesメソッドが一回だけ呼ばれているか")
+        XCTAssertEqual(hudShow.value, .progress, "progressタイプのHUDが表示されているか")
+        XCTAssertEqual(query, .mock, "検索クエリが流せているか")
+        XCTAssertEqual(repositoryInfoModels.value, MockData.noHitRepositoryInfoModel(), "MockのRepositoriesが返ってくるか")
+        XCTAssertNotNil(hudHide.value, "HUDが非表示になっているか")
+        XCTAssertNotNil(noResultsAlert.value, "検索がヒットしなかった場合のアラートが表示されるか")
     }
 }
 

--- a/Podfile
+++ b/Podfile
@@ -5,17 +5,18 @@ target 'BeyondCTAProject' do
   # Comment the next line if you don't want to use dynamic frameworks
   use_frameworks!
 
-  pod 'SwiftLint'
-  pod 'SwiftGen'
-  pod 'Unio'
-  pod 'RxSwift'
-  pod 'RxCocoa'
+	pod 'SwiftLint'
+	pod 'SwiftGen'
+	pod 'Unio'
+	pod 'RxSwift'
+	pod 'RxCocoa'
 	pod 'Moya'
 	pod 'Moya/RxSwift'
-  pod 'SnapKit', '~> 5.6.0'
+	pod 'SnapKit', '~> 5.6.0'
 	pod 'PKHUD'
 	pod 'RxNuke'
 	pod "MarkdownView"
+	pod 'SwiftMessages'
 
   # Pods for BeyondCTAProject
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -24,6 +24,9 @@ PODS:
   - SnapKit (5.6.0)
   - SwiftGen (6.5.1)
   - SwiftLint (0.47.1)
+  - SwiftMessages (9.0.6):
+    - SwiftMessages/App (= 9.0.6)
+  - SwiftMessages/App (9.0.6)
   - Unio (0.11.0):
     - RxRelay (~> 6.0)
     - RxSwift (~> 6.0)
@@ -40,6 +43,7 @@ DEPENDENCIES:
   - SnapKit (~> 5.6.0)
   - SwiftGen
   - SwiftLint
+  - SwiftMessages
   - Unio
 
 SPEC REPOS:
@@ -57,6 +61,7 @@ SPEC REPOS:
     - SnapKit
     - SwiftGen
     - SwiftLint
+    - SwiftMessages
     - Unio
 
 SPEC CHECKSUMS:
@@ -73,8 +78,9 @@ SPEC CHECKSUMS:
   SnapKit: e01d52ebb8ddbc333eefe2132acf85c8227d9c25
   SwiftGen: a6d22010845f08fe18fbdf3a07a8e380fd22e0ea
   SwiftLint: f80f1be7fa96d30e0aa68e58d45d4ea1ccaac519
+  SwiftMessages: f0c7ef4705a570ad6c5e208b611f4333e660ed92
   Unio: 6e57bd33dbcf38d281b0b420f75c0eae3bef0cf3
 
-PODFILE CHECKSUM: 0db3334ca9de4cbce1bd59e04e8cb2ce6515de2d
+PODFILE CHECKSUM: d06bfc39c96e773fefc7d572361477ae6b1d2c99
 
-COCOAPODS: 1.10.2
+COCOAPODS: 1.11.3


### PR DESCRIPTION
### 検索結果がヒットしなかった時のアラートを実装↓

### 対応した内容

- SwiftMessagesのインストール
- 検索結果のアイテムがisEmptyだった場合View側に通知
- テストコード
<img src="https://user-images.githubusercontent.com/55890106/177576817-eacc39bd-2f80-4993-a0e4-3592ea91dec8.png" width="300px">


**mockoloが動いていないので(MockResult.swiftをプッシュしてない)、現状手元でしかコンパイルは通らない**
