### PR TITLE
iPad非対応、画面回転不可能

### DIFF
--- a/BeyondCTAProject/Info.plist
+++ b/BeyondCTAProject/Info.plist
@@ -4,14 +4,12 @@
 <dict>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
-	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
-	<key>UILaunchStoryboardName</key>
-	<string>LaunchScrreen</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -29,5 +27,11 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScrreen</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
iPad非対応にしても、iPad上でiPhoneアプリとしてビルド可能（逆はビルドできないようになってた）
また、追加で画面の回転をできないようにしました。
![image](https://user-images.githubusercontent.com/83959618/183712772-25c50498-0fcd-4841-a0e3-c0cee9a35dc8.png)
